### PR TITLE
Use `toolsItems` instead `children.push` for clear LSCache button

### DIFF
--- a/js/src/admin/addPurgeLSCacheButton.tsx
+++ b/js/src/admin/addPurgeLSCacheButton.tsx
@@ -16,9 +16,8 @@ function handleClearLSCache() {
 }
 
 export default () => {
-  extend(StatusWidget.prototype, 'items', (items: ItemList) => {
-    const tools = items.get('tools');
+  extend(StatusWidget.prototype, 'toolsItems', (items: ItemList) => {
 
-    tools.children.push(<Button onclick={handleClearLSCache}>{app.translator.trans('acpl-lscache.admin.purge_all')}</Button>);
+    items.add('clearLSCache', <Button onclick={handleClearLSCache}>{app.translator.trans('acpl-lscache.admin.purge_all')}</Button>)
   });
 };


### PR DESCRIPTION
The `children.push` not working on `flarum/core` dev branch.

![](https://cdn.discordapp.com/attachments/369174406909394944/931910093455392788/unknown.png)

So this PR will fix that problem.

Tested on `flarum/core1.0.0`, `flarum/core:dev`

